### PR TITLE
support JSON service account credentials using ServiceAccountCredentials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     keywords='git-annex gcs Google Cloud Storage',
     install_requires=[
         'google-api-python-client',
+        'oauth2client<4.0.0'
         'PyCrypto',
     ],
     py_modules=[


### PR DESCRIPTION
strore under `-creds-v2` suffix for more explicit migration path from previous version

it passes testremote --fast and most of testremote checks.
